### PR TITLE
Updated stack files to use correct images + other minor mods

### DIFF
--- a/docker-compose-swarm.yml
+++ b/docker-compose-swarm.yml
@@ -16,7 +16,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   engine1:
-    image: qlikea/engine:12.15.0
+    image: qlikea/engine:12.21.0
     ports:
       - "9176:9076"
     deploy:
@@ -25,7 +25,7 @@ services:
         constraints: [node.role == manager]
 
   engine2:
-    image: qlikea/engine:12.15.0
+    image: qlikea/engine:12.21.0
     ports:
       - "9276:9076"
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,11 +12,11 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   engine1:
-    image: qlikea/engine
+    image: qlikea/engine:12.21.0
     ports:
       - "9176:9076"
 
   engine2:
-    image: qlikea/engine
+    image: qlikea/engine:12.21.0
     ports:
       - "9276:9076"


### PR DESCRIPTION
Updated the mira example stack files with correct images and removed some unnecessary stuff.
The idea is that these stack files are provided as simple examples of how to start Mira in different operation modes and engines started along to quickly be able to show the Mira capabilities.