### PR TITLE
Removed unneeded env var from compose files

### DIFF
--- a/docker-compose-swarm.yml
+++ b/docker-compose-swarm.yml
@@ -6,8 +6,6 @@ services:
     ports:
       - "9100:9100"
     command: --mode swarm
-    environment:
-      - QIX_ENGINE_IMAGE_NAME=qlikea/engine
     deploy:
       mode: global
       placement:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
     ports:
       - "9100:9100"
     command: --mode local
-    environment:
-      - QIX_ENGINE_IMAGE_NAME=qlikea/engine
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 

--- a/test/integration/docker-compose-integration-local.yml
+++ b/test/integration/docker-compose-integration-local.yml
@@ -6,8 +6,6 @@ services:
     ports:
       - "9100:9100"
     command: --mode local
-    environment:
-      - QIX_ENGINE_IMAGE_NAME=qlikea/engine
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 


### PR DESCRIPTION
Since mira defaults to `qlikea/engine` we don't need the env var in the compose files. Makes them somewhat cleaner.