### PR TITLE
Add API Governance properties to api doc

### DIFF
--- a/doc/api-doc.yml
+++ b/doc/api-doc.yml
@@ -20,6 +20,8 @@ tags:
     description: "List available QIX Engines"
   - name: "health"
     description: "Health status of the service"
+x-qlik-visibility: "private"
+x-qlik-stability: "experimental"
 paths:
   /engines:
     get:


### PR DESCRIPTION
This relates to #81.

Two properties are needed in the api spec to specify the maturity of the API. These properties are needed for the api to be compliant with qlik api governance model.