### PR TITLE
Remove the 100 chars max length lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
     "extends": "airbnb-base",
     "rules": {
-        "no-console": "error"
+        "no-console": "error",
+        "max-len": "off"
     },
     "env": { 
       "node": true


### PR DESCRIPTION
I really dont like the 100 chars max length lint rule.

I think it forces us to make the code uglier in some places where we have to make stupid line breaks and I dont think it gives any value.

I want to remove it.
