### PR TITLE
Add healthcheck to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,11 @@ FROM node:8-alpine
 RUN apk --update add curl
 RUN mkdir -p /app/
 
+ARG PORT=9100
+EXPOSE $PORT
+
 # check every 30s to ensure this service returns HTTP 200
-HEALTHCHECK CMD curl -fs http://localhost:9100/v1/health || exit 1
+HEALTHCHECK CMD curl -fs http://localhost:$PORT/v1/health || exit 1
 
 WORKDIR /app/
 COPY package.json ./


### PR DESCRIPTION
This relates to #28.

Docker now has support for healthchecks in the Dockerfile.

https://docs.docker.com/engine/reference/builder/#healthcheck

The healthcheck will be executed every 30 seconds, and if you run ```docker ps``` you will see the health status of the mira containers.