### PR TITLE
Adding timestamp to response

### DIFF
--- a/src/EngineEntry.js
+++ b/src/EngineEntry.js
@@ -9,6 +9,7 @@ async function checkHealth() {
   try {
     const health = await this.healthFetcher.fetch(this.properties.engine.ip, this.properties.engine.port, '/healthcheck');
     this.properties.engine.health = health;
+    this.properties.engine.lastRefreshed = new Date().toISOString();
   } catch (err) {
     logger.warn(`Engine health check failed on ${this.properties.engine.ip}:${this.properties.engine.port}`);
     this.properties.engine.health = undefined;


### PR DESCRIPTION
This adds the timestamp to the response, only for /health right now and not /metrics since we do not yet support metrics