### PR TITLE
Update README documentation on engine labeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Mira searches for a specific label key to identify an engine instance. By defaul
 
 ### Port Labeling
 
-In addition to the disovery label described above, Mira also identifies labels on an engine instance to determine which ports it serves the QIX API (websocket) on, and which port it serves the `/metrics` endpoint on. By default, Mira identifies and uses the values of the labels `qix-engine-api-port` and `qix-engine-metrics-port`. These label keys can be configured using the environment variables `MIRA_ENGINE_API_PORT_LABEL` and `MIRA_ENGINE_METRICS_PORT_LABEL` respectibely.
+In addition to the disovery label described above, Mira also identifies labels on an engine instance to determine which ports it serves the QIX API (websocket) on, and which port it serves the `/metrics` endpoint on. By default, Mira identifies and uses the values of the labels `qix-engine-api-port` and `qix-engine-metrics-port`. These label keys can be configured using the environment variables `MIRA_ENGINE_API_PORT_LABEL` and `MIRA_ENGINE_METRICS_PORT_LABEL` respectively.
 
 If an engine instance does not have these labels set, Mira defaults to setting the QIX API port to `9076` and the `/metrics` port to `9090`
 


### PR DESCRIPTION
Updated the README to give more details and emphasize using labels on engines for the Mira discovery process.

Removed some examples that showed configuration of label keys. I don't think this is something we need to encourage. Using default label keys is preferred. By reading about the env vars it should be possible to configure this if needed.