### PR TITLE
Install dependencies before copying src in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,12 @@ EXPOSE $MIRA_API_PORT
 HEALTHCHECK CMD curl -fs http://localhost:$MIRA_API_PORT/v1/health || exit 1
 
 WORKDIR /app/
-COPY package.json ./
-COPY src src/
-COPY doc/api-doc.yml doc/
 
+# install dependencies before copying src to make use of docker cache layering
+COPY package.json ./
 RUN npm install --quiet --production
+
+COPY doc/api-doc.yml doc/
+COPY src src/
+
 ENTRYPOINT ["node", "./src/index.js"]


### PR DESCRIPTION
This relates to #28.

To make use of the docker cache layering when building a docker image we should copy the src as the last step in the dockerfile. This way we can reuse the cache for the npm dependencies even if the src has changed. 