### PR TITLE
Fix close on SIGTERM and improved logging prints when adding engines

### DIFF
--- a/src/EngineDiscovery.js
+++ b/src/EngineDiscovery.js
@@ -28,7 +28,7 @@ async function discover() {
     if (!this.engineMap.has(item.key)) {
       const engineEntry = new EngineEntry(
         item, this.healthRefreshRate);
-      logger.info(`Engine discovered: ${engineEntry.properties.engine.ip}:${engineEntry.properties.engine.port}`);
+      logger.info(`Engine discovered at address: ${engineEntry.properties.engine.ip}:${engineEntry.properties.engine.port} with key: ${item.key}`);
       this.engineMap.add(item.key, engineEntry);
     }
   });

--- a/src/EngineEntry.js
+++ b/src/EngineEntry.js
@@ -57,14 +57,14 @@ class EngineEntry {
     if (labels[Config.engineAPIPortLabel]) {
       this.properties.engine.port = parseInt(labels[Config.engineAPIPortLabel], 10);
     } else {
-      logger.info(`Engine entry missing api port label: ${Config.engineAPIPortLabel}, defaulting to port: ${Config.defaultEngineAPIPort}`);
+      logger.debug(`Engine entry missing api port label: ${Config.engineAPIPortLabel}, defaulting to port: ${Config.defaultEngineAPIPort}`);
       this.properties.engine.port = Config.defaultEngineAPIPort;
     }
 
     if (labels[Config.engineMetricsPortLabel]) {
       this.properties.engine.metricsPort = parseInt(labels[Config.engineMetricsPortLabel], 10);
     } else {
-      logger.info(`Engine entry missing metrics port label: ${Config.engineMetricsPortLabel}, defaulting to port: ${Config.defaultEngineMetricsPort}`);
+      logger.debug(`Engine entry missing metrics port label: ${Config.engineMetricsPortLabel}, defaulting to port: ${Config.defaultEngineMetricsPort}`);
       this.properties.engine.metricsPort = Config.defaultEngineMetricsPort;
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ Config.init();
 const router = require('./Routes');
 
 const app = new Koa();
+let server;
 
 const document = swagger.loadDocumentSync(path.join(__dirname, './../doc/api-doc.yml'));
 
@@ -24,7 +25,7 @@ function onUnhandledError(err) {
  */
 
 process.on('SIGTERM', () => {
-  app.close(() => {
+  server.close(() => {
     logger.info('Process exiting on SIGTERM');
     process.exit(0);
   });
@@ -40,7 +41,7 @@ app
   .use(router.allowedMethods());
 
 if (process.env.NODE_ENV !== 'test') {
-  app.listen(Config.miraApiPort);
+  server = app.listen(Config.miraApiPort);
   logger.info(`Listening on port ${Config.miraApiPort}`);
 }
 


### PR DESCRIPTION
* Mira was not properly closed when receiving SIGTERM.
* Now also logging the engine key when engine is discovered to be able to map it to the engine address.