### PR TITLE
test:component:local need longer timeout. Increased from 2000 to 5000

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npm run test:unit",
     "test:unit": "aw-test-runner cover ./test/unit",
     "test:component": "npm run test:component:local && npm run test:component:swarm && npm run test:component:kubernetes",
-    "test:component:local": "cross-env NODE_ENV=test MIRA_MODE=local aw-test-runner ./test/component/local",
+    "test:component:local": "cross-env NODE_ENV=test MIRA_MODE=local aw-test-runner ./test/component/local --timeout 5000" ,
     "test:component:swarm": "cross-env NODE_ENV=test MIRA_MODE=swarm aw-test-runner ./test/component/swarm",
     "test:component:kubernetes": "cross-env NODE_ENV=test MIRA_MODE=kubernetes aw-test-runner ./test/component/kubernetes",
     "test:integration": "npm run test:integration:local && npm run test:integration:dredd",


### PR DESCRIPTION
Fixes #155

On my machine test failed with the default 2000 ms timeout. 3000 ms seemed to work, but setting to safe limit of 5000.