### PR TITLE
Use `call` instead of `bind` for recurring engine discovery

### DIFF
--- a/src/EngineDiscovery.js
+++ b/src/EngineDiscovery.js
@@ -31,7 +31,7 @@ async function discover() {
       this.engineMap.add(item.key, engineEntry);
     }
   });
-  setTimeout(discover.bind(this), this.discoveryRefreshRate);
+  setTimeout(() => discover.call(this), this.discoveryRefreshRate);
 }
 
 /**


### PR DESCRIPTION
This avoids creating a new copy of  the `discover()` function in each iteration.