### PR TITLE
Check engine health every second when running integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           command: |
             # Spin up a local setup with the previously built docker image.
             VER=$(cat workspace/version.txt)
-            TAG=:${VER} MIRA_ENGINE_DISCOVERY_REFRESH_RATE=1000 MIRA_ENGINE_HEALTH_REFRESH_RATE=5000 docker-compose up -d
+            TAG=:${VER} MIRA_ENGINE_DISCOVERY_REFRESH_RATE=1000 MIRA_ENGINE_HEALTH_REFRESH_RATE=1000 docker-compose up -d
             # Find IP address of gateway
             CONTAINER_ID=$(docker ps -aqf "name=mira_mira")
             TEST_HOST=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.Gateway}}{{end}}' "$CONTAINER_ID")


### PR DESCRIPTION
In circle ci the integration test job sporadically fails due to the first health check failing against an engine. The next health check succeeds but since the interval is set to 5 seconds the integration tests might already have failed.

Changing the health check interval to 1 sec instead.