### PR TITLE
Remove teardown of swarm and kubernetes in CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,11 +147,6 @@ jobs:
             done
 
             echo "Mira is up and running!"
-      - run:
-          name: Remove deployment and leave swarm
-          command: |
-            docker stack rm mira-swarm
-            docker swarm leave --force
 
   # Job for testing Mira in kubernetes
   kubernetes:
@@ -196,9 +191,6 @@ jobs:
             # Check mira health
             MIRA_URL=$(sudo minikube service mira --url)
             curl -fs "$MIRA_URL/v1/health"
-      - run:
-          name: Kubernetes delete mira
-          command: sudo kubectl delete -f ./examples/kubernetes/
 
   # Job for testing Mira in dns mode
   dns:


### PR DESCRIPTION
In Circle Ci the removal of a swarm deployment sporadically fails. Since swarm removal is not part of Mira functionality lets remove it from the CCI config. Same goes for Kubernetes.

Failing example:
https://circleci.com/gh/qlik-ea/mira/1167