### PR TITLE
Always require a RELEASE_TYPE when creating a release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -36,6 +36,7 @@ function pre_flight_checks() {
 function check_release_type() {
   if [ "$RELEASE_TYPE" != patch ] && [ "$RELEASE_TYPE" != minor ] && [ "$RELEASE_TYPE" != major ]; then
     echo "Invalid RELEASE_TYPE specified"
+    print_usage
     exit 1
   fi
 }


### PR DESCRIPTION
The `release.sh` used for creating Mira releases assumed a patch release if a type was not given.

This could lead to unwanted releases if e.g. running `./release.sh ?`. Removed the assumption of patch and the script will now exit if `RELEASE_TYPE` is not set or is invalid, and also print usage instructions.