### PR TITLE
Remove redundant tag of docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,10 +317,6 @@ jobs:
       - run:
           name: Push image to Docker Hub
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              VER=$(cat /tmp/workspace/version.txt)
-              docker tag $DOCKER_REPO:$VER
-            fi
             docker push $DOCKER_REPO
 
 workflows:


### PR DESCRIPTION
The previous PR was incorrect. The docker image is already tagged in the build step so there is no need to add any more tags before pushing to dockerhub.