### PR TITLE
Now the cache is kept on orchestration failures

### DIFF
--- a/src/EngineDiscovery.js
+++ b/src/EngineDiscovery.js
@@ -46,8 +46,7 @@ async function discover() {
   } catch (err) {
     // Log error and delete engine cache if this is the first failure
     if (this.discoverySuccessful) {
-      logger.error(`Unable to discover engines with error: ${err}. Invalidating engine cache.`);
-      this.engineMap.deleteAll();
+      logger.error(`Unable to discover engines with error: ${err}.`);
       this.discoverySuccessful = false;
     }
   }


### PR DESCRIPTION
Instead of returning an empty list of engines when the orchestration fails we return what was in the cache before the failure. This allows for instance the API server in kubernetes to fail and reboot without affecting traffic