### PR TITLE
Remove check of last enginediscovery was successful

### DIFF
--- a/src/EngineDiscovery.js
+++ b/src/EngineDiscovery.js
@@ -93,10 +93,6 @@ class EngineDiscovery {
    * @returns {Promise<EngineReturnSpec[]>} Promise to an array of engines.
    */
   async list(query) {
-    if (!this.discoverySuccessful) {
-      throw new Error('Last engine discovery failed');
-    }
-
     const engines = this.engineMap.all();
 
     if (query.format === 'condensed') {

--- a/test/component/swarm/component-swarm.spec.js
+++ b/test/component/swarm/component-swarm.spec.js
@@ -78,24 +78,3 @@ describe('Mira in docker swarm mode', () => {
 
   after(() => nock.cleanAll());
 });
-
-describe('Mira in docker swarm mode but no access to docker daemon', () => {
-  let app;
-
-  before(async () => {
-    // Mock docker.sock
-    nock('http://localhost:8001').filteringPath(() => '/tasks').get('/tasks').times(10)
-      .reply(503, 'This node is not a swarm manager.');
-    app = require('../../../src/index'); // eslint-disable-line global-require
-    await sleep(1000); // Sleep to make room for status checks to succeed
-  });
-
-  describe('GET /engines', () => {
-    it('should return 503 Service Unavailable', async () => {
-      const res = await request(app.listen()).get('/v1/engines');
-      expect(res.status).to.equal(503);
-    });
-  });
-
-  after(() => nock.cleanAll());
-});

--- a/test/unit/EngineDiscovery.spec.js
+++ b/test/unit/EngineDiscovery.spec.js
@@ -131,34 +131,6 @@ describe('EngineDiscovery', () => {
       expect(second.engine).to.deep.equal(engine3.engine);
     });
 
-    it('should throw error if the last discovery was failed', async () => {
-      listEnginesStub = sinon.stub(FakeDockerClient, 'listEngines')
-        .onFirstCall()
-        .returns(engines1)
-        .throws(new Error('Orchestration not responding'));
-
-      engineDiscovery = new EngineDiscovery(FakeDockerClient, 20, 100000);
-      await engineDiscovery.start();
-      await sleep(50);
-
-      try {
-        await engineDiscovery.list({});
-      } catch (err) { return; }
-      throw new Error('Should have thrown an error');
-    });
-
-    it('should throw error if the first discovery failed', async () => {
-      listEnginesStub = sinon.stub(FakeDockerClient, 'listEngines').throws(new Error('Orchestration not responding'));
-      engineDiscovery = new EngineDiscovery(FakeDockerClient, 20, 100000);
-      await engineDiscovery.start();
-      await sleep(50);
-
-      try {
-        await engineDiscovery.list({});
-      } catch (err) { return; }
-      throw new Error('Should have thrown an error');
-    });
-
     it('should list all discovered engines if a previous but not last discovery was failed', async () => {
       listEnginesStub = sinon.stub(FakeDockerClient, 'listEngines')
         .onFirstCall()


### PR DESCRIPTION
We should always return our list of engines when requested, even if it might be outdated.

This closes  #301