### PR TITLE
Run dockerfile as non-root for secure systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,7 @@ EXPOSE $MIRA_API_PORT
 
 ENV MIRA_CONTAINERIZED true
 
+# Run as non-root user for secure systems
+USER 63000:63000
+
 ENTRYPOINT ["./docker-entrypoint.sh", "node", "./src/index.js"]


### PR DESCRIPTION
In secure systems, the `root` user cannot be used. The industry recommendation is typically to run as a numbered user to avoid conflicts with actual host users.

This PR sets the user and group to `63000` to be able to run in those conditions.