### PR TITLE
Run dockerfile as non-root for secure systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV MIRA_CONTAINERIZED true
 
 # Run as non-root user for secure systems
 USER 63000:63000
-
+RUN mkdir -p /home/63000/
 RUN echo "if [ -e /var/run/docker.sock ]; then sudo chown 63000:63000 /var/run/docker.sock; fi" >> /home/63000/.bashrc
 
 ENTRYPOINT ["./docker-entrypoint.sh", "node", "./src/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,7 @@ EXPOSE $MIRA_API_PORT
 ENV MIRA_CONTAINERIZED true
 
 # Run as non-root user for secure systems
-RUN mkdir -p /home/63000 && chown 63000:63000 /home/63000
 USER 63000:63000
-RUN echo "if [ -e /var/run/docker.sock ]; then sudo chown 63000:63000 /var/run/docker.sock; fi" >> /home/63000/.bashrc
 
 ENTRYPOINT ["./docker-entrypoint.sh", "node", "./src/index.js"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,7 @@ EXPOSE $MIRA_API_PORT
 
 ENV MIRA_CONTAINERIZED true
 
+# Run as non-root user for secure systems
+USER 63000:63000
+
 ENTRYPOINT ["./docker-entrypoint.sh", "node", "./src/index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,7 @@ ENV MIRA_CONTAINERIZED true
 # Run as non-root user for secure systems
 USER 63000:63000
 
+RUN echo "if [ -e /var/run/docker.sock ]; then sudo chown 63000:63000 /var/run/docker.sock; fi" >> /home/63000/.bashrc
+
 ENTRYPOINT ["./docker-entrypoint.sh", "node", "./src/index.js"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ EXPOSE $MIRA_API_PORT
 ENV MIRA_CONTAINERIZED true
 
 # Run as non-root user for secure systems
+RUN mkdir -p /home/63000 && chown 63000:63000 /home/63000
 USER 63000:63000
-RUN mkdir -p /home/63000/
 RUN echo "if [ -e /var/run/docker.sock ]; then sudo chown 63000:63000 /var/run/docker.sock; fi" >> /home/63000/.bashrc
 
 ENTRYPOINT ["./docker-entrypoint.sh", "node", "./src/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,10 @@ services:
     ports:
       - "9100:9100"
     environment:
-     - MIRA_MODE=local
+      - MIRA_MODE=local
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    user: root
 
   engine1:
     image: qlikcore/engine:12.311.0

--- a/examples/dns/docker-compose-dns.yml
+++ b/examples/dns/docker-compose-dns.yml
@@ -12,6 +12,7 @@ services:
       mode: global
       placement:
         constraints: [node.role == manager]
+    user: root
 
   qix-engine:
     image: qlikcore/engine:12.311.0

--- a/examples/swarm/docker-compose-swarm.yml
+++ b/examples/swarm/docker-compose-swarm.yml
@@ -11,6 +11,7 @@ services:
         constraints: [node.role == manager]
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    user: root
 
   qix-engine:
     image: qlikcore/engine:12.311.0


### PR DESCRIPTION
In secure systems, the `root` user cannot be used. The industry recommendation is typically to run as a numbered user to avoid conflicts with actual host users.

This PR sets the user and group to `63000` to be able to run in those conditions.

Replaces #412