### PR TITLE
Support targetting a specific namespace within k8s

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ jobs:
       - run:
           name: Cleanup services
           command: |
-            sudo kubectl delete -f ./examples/kubernetes/plain -recursive=true
+            sudo kubectl delete -f ./examples/kubernetes/plain --recursive
       - run:
           name: Give default service account view access to Kubernetes API only within the namespace
           command: sudo kubectl create -f ./examples/kubernetes/plain.namespaced/rbac/rbac-config.yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ jobs:
       - run:
           name: Cleanup services
           command: |
-            sudo kubectl delete -f ./examples/kubernetes/plain
+            sudo kubectl delete -f ./examples/kubernetes/plain -recursive=true
       - run:
           name: Give default service account view access to Kubernetes API only within the namespace
           command: sudo kubectl create -f ./examples/kubernetes/plain.namespaced/rbac/rbac-config.yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,8 +241,8 @@ jobs:
           name: Give default service account view access to Kubernetes API
           command: sudo kubectl create -f ./examples/kubernetes/plain/rbac/rbac-config.yaml
       - run:
-          name: Accept EULA
-          command: grep -rl AcceptEULA ./examples/kubernetes/plain/ | xargs sed -i 's/AcceptEULA=no/AcceptEULA=yes/g'
+          name: Accept EULA for plain and plain namespaced.
+          command: grep -rl AcceptEULA ./examples/kubernetes/plain*/ | xargs sed -i 's/AcceptEULA=no/AcceptEULA=yes/g'
       - run:
           name: Kubernetes plain mira
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,6 +265,9 @@ jobs:
           command: |
             sudo kubectl delete -f ./examples/kubernetes/plain
       - run:
+          name: Give default service account view access to Kubernetes API only within the namespace
+          command: sudo kubectl create -f ./examples/kubernetes/plain.namespaced/rbac/rbac-config.yaml
+      - run:
           name: Kubernetes plain namespaced mira
           command: |
             VER=$(cat /tmp/workspace/version.txt)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,95 +260,12 @@ jobs:
           command: |
             MIRA_URL=$(sudo minikube service mira --url)
             ./.circleci/verify_qix_engines.sh $MIRA_URL
-
-
-# Job for testing Mira in kubernetes mode with helm and plain charts + namespace target
-  namespaced-kubernetes:
-    machine: true
-    environment:
-      CHANGE_MINIKUBE_NONE_USER: true
-      DOCKER_REPO: qlikcore/mira
-    working_directory: ~/mira
-    steps:
-      - attach_workspace:
-          at: /tmp/workspace
       - run:
-          name: Import previously built docker image
-          command: docker load < /tmp/workspace/mira_image.tar
-      - checkout
-      - run:
-          name: Install Helm
+          name: Cleanup services
           command: |
-            curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
-            chmod 700 get_helm.sh
-            ./get_helm.sh
+            sudo kubectl delete -f ./examples/kubernetes/plain
       - run:
-          name: Lint charts
-          command: |
-            helm lint ./examples/kubernetes/helm/charts/mira
-            helm lint ./examples/kubernetes/helm/charts/engine --set acceptEULA=yes
-      - run:
-          name: Install Kubectl
-          command: |
-            curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.3/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-      - run:
-          name: Install Minikube
-          command: |
-            curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-      - run:
-          name: Start Minikube
-          command: |
-            sudo minikube start --vm-driver=none --kubernetes-version=v1.9.0 --extra-config=apiserver.Authorization.Mode=RBAC
-            sudo minikube update-context
-      - run:
-          name: Install socat (needed by helm)
-          command: |
-            sudo apt-get update
-            sudo apt-get install socat
-      - run:
-          name: Install nsenter (needed by helm)
-          command: |
-            cd /tmp; curl https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.25/util-linux-2.25.tar.gz | tar -zxf-; cd util-linux-2.25;
-            sudo apt-get install autopoint autoconf libtool automake
-            ./configure --without-python --disable-all-programs --enable-nsenter --without-ncurses
-            sudo make nsenter; sudo cp nsenter /usr/local/bin
-      - run:
-          name: Create service account for cluster-admin role (Helm)
-          command: sudo kubectl create -f ./examples/kubernetes/helm/rbac/rbac-config.yaml
-      - run:
-          name: Helm init and wait for tiller to be running
-          command: sudo helm init --service-account tiller --debug; sudo kubectl rollout status -w deployment/tiller-deploy --namespace=kube-system;
-      - run:
-          name: Helm install charts
-          command: |
-            VER=$(cat /tmp/workspace/version.txt)
-            sudo helm dependency build ./examples/kubernetes/helm/
-            sudo helm install ./examples/kubernetes/helm/ --set mira.service.type=NodePort,mira.image.repository=$DOCKER_REPO,mira.image.tag=$VER,engine.acceptEULA=yes --name test --debug
-      - run:
-          name: Check health of services
-          command: |
-            # Check mira health
-            MIRA_URL=$(sudo minikube service test-mira --url)
-            curl -fs "$MIRA_URL/health"
-      - run:
-          name: Verify number of QIX Engines found
-          command: |
-            MIRA_URL=$(sudo minikube service test-mira --url)
-            ./.circleci/verify_qix_engines.sh $MIRA_URL
-      - run:
-          name: Helm delete
-          command: sudo helm delete test --debug
-      - run:
-          name: Delete service account for cluster-admin role (Helm)
-          command: sudo kubectl delete -f ./examples/kubernetes/helm/rbac/rbac-config.yaml
-      - run:
-          name: Give default service account view access to Kubernetes API
-          command: sudo kubectl create -f ./examples/kubernetes/plain/rbac/rbac-config.yaml
-      - run:
-          name: Accept EULA
-          command: grep -rl AcceptEULA ./examples/kubernetes/plain/ | xargs sed -i 's/AcceptEULA=no/AcceptEULA=yes/g'
-      - run:
-          name: Kubernetes plain mira
+          name: Kubernetes plain namespaced mira
           command: |
             VER=$(cat /tmp/workspace/version.txt)
             sudo kubectl create -f ./examples/kubernetes/plain.namespaced
@@ -438,9 +355,6 @@ workflows:
           requires:
             - build
       - kubernetes:
-          requires:
-            - build
-      - namespaced-kubernetes:
           requires:
             - build
       - dns:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,6 +261,110 @@ jobs:
             MIRA_URL=$(sudo minikube service mira --url)
             ./.circleci/verify_qix_engines.sh $MIRA_URL
 
+
+# Job for testing Mira in kubernetes mode with helm and plain charts + namespace target
+  namespaced-kubernetes:
+    machine: true
+    environment:
+      CHANGE_MINIKUBE_NONE_USER: true
+      DOCKER_REPO: qlikcore/mira
+    working_directory: ~/mira
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - run:
+          name: Import previously built docker image
+          command: docker load < /tmp/workspace/mira_image.tar
+      - checkout
+      - run:
+          name: Install Helm
+          command: |
+            curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+            chmod 700 get_helm.sh
+            ./get_helm.sh
+      - run:
+          name: Lint charts
+          command: |
+            helm lint ./examples/kubernetes/helm/charts/mira
+            helm lint ./examples/kubernetes/helm/charts/engine --set acceptEULA=yes
+      - run:
+          name: Install Kubectl
+          command: |
+            curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.9.3/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+      - run:
+          name: Install Minikube
+          command: |
+            curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+      - run:
+          name: Start Minikube
+          command: |
+            sudo minikube start --vm-driver=none --kubernetes-version=v1.9.0 --extra-config=apiserver.Authorization.Mode=RBAC
+            sudo minikube update-context
+      - run:
+          name: Install socat (needed by helm)
+          command: |
+            sudo apt-get update
+            sudo apt-get install socat
+      - run:
+          name: Install nsenter (needed by helm)
+          command: |
+            cd /tmp; curl https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.25/util-linux-2.25.tar.gz | tar -zxf-; cd util-linux-2.25;
+            sudo apt-get install autopoint autoconf libtool automake
+            ./configure --without-python --disable-all-programs --enable-nsenter --without-ncurses
+            sudo make nsenter; sudo cp nsenter /usr/local/bin
+      - run:
+          name: Create service account for cluster-admin role (Helm)
+          command: sudo kubectl create -f ./examples/kubernetes/helm/rbac/rbac-config.yaml
+      - run:
+          name: Helm init and wait for tiller to be running
+          command: sudo helm init --service-account tiller --debug; sudo kubectl rollout status -w deployment/tiller-deploy --namespace=kube-system;
+      - run:
+          name: Helm install charts
+          command: |
+            VER=$(cat /tmp/workspace/version.txt)
+            sudo helm dependency build ./examples/kubernetes/helm/
+            sudo helm install ./examples/kubernetes/helm/ --set mira.service.type=NodePort,mira.image.repository=$DOCKER_REPO,mira.image.tag=$VER,engine.acceptEULA=yes --name test --debug
+      - run:
+          name: Check health of services
+          command: |
+            # Check mira health
+            MIRA_URL=$(sudo minikube service test-mira --url)
+            curl -fs "$MIRA_URL/health"
+      - run:
+          name: Verify number of QIX Engines found
+          command: |
+            MIRA_URL=$(sudo minikube service test-mira --url)
+            ./.circleci/verify_qix_engines.sh $MIRA_URL
+      - run:
+          name: Helm delete
+          command: sudo helm delete test --debug
+      - run:
+          name: Delete service account for cluster-admin role (Helm)
+          command: sudo kubectl delete -f ./examples/kubernetes/helm/rbac/rbac-config.yaml
+      - run:
+          name: Give default service account view access to Kubernetes API
+          command: sudo kubectl create -f ./examples/kubernetes/plain/rbac/rbac-config.yaml
+      - run:
+          name: Accept EULA
+          command: grep -rl AcceptEULA ./examples/kubernetes/plain/ | xargs sed -i 's/AcceptEULA=no/AcceptEULA=yes/g'
+      - run:
+          name: Kubernetes plain mira
+          command: |
+            VER=$(cat /tmp/workspace/version.txt)
+            sudo kubectl create -f ./examples/kubernetes/plain.namespaced
+            sudo kubectl set image deployment/mira mira="$DOCKER_REPO:$VER"
+      - run:
+          name: Check health of services
+          command: |
+            # Check mira health
+            MIRA_URL=$(sudo minikube service mira --url)
+            curl -fs "$MIRA_URL/health"
+      - run:
+          name: Verify number of QIX Engines found
+          command: |
+            MIRA_URL=$(sudo minikube service mira --url)
+            ./.circleci/verify_qix_engines.sh $MIRA_URL
+
   # Job for testing Mira in dns mode
   dns:
     machine: true
@@ -334,6 +438,9 @@ workflows:
           requires:
             - build
       - kubernetes:
+          requires:
+            - build
+      - namespaced-kubernetes:
           requires:
             - build
       - dns:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,38 +5,39 @@
 #  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
 
 file_env() {
-	local var="$1"
-	local fileVar="${var}_FILE"
-	local def="${2:-}"
-	local val="$def"
+  local var="$1"
+  local fileVar="${var}_FILE"
+  local def="${2:-}"
+  local val="$def"
 
-#Defaults to enviroment without _FILE if set, else to *_FILE enviroment
-	if [ "${!var:-}" ]; then
-		val="${!var}"
-	elif [ "${!fileVar:-}" ]; then
-		val="$(< "${!fileVar}")"
-	fi
-	export "$var"="$val"
-	unset "$fileVar"
+  #Defaults to enviroment without _FILE if set, else to *_FILE enviroment
+  if [ "${!var:-}" ]; then
+    val="${!var}"
+  elif [ "${!fileVar:-}" ]; then
+    val="$(< "${!fileVar}")"
+  fi
+  export "$var"="$val"
+  unset "$fileVar"
 }
 
 envs=(
-		MIRA_MODE
-		MIRA_DISCOVERY_LABEL
-		MIRA_DISCOVERY_HOSTNAME
-		MIRA_ENGINE_API_PORT_LABEL
-		MIRA_ENGINE_METRICS_PORT_LABEL
-		MIRA_ENGINE_DISCOVERY_INTERVAL
-		MIRA_ENGINE_UPDATE_INTERVAL
-		MIRA_KUBERNETES_PROXY_PORT
-		MIRA_LOG_LEVEL
-		MIRA_ALLOWED_RESPONSE_TIME
-		MIRA_SWARM_ENGINES_NETWORKS
-		MIRA_ROLLBAR_ACCESS_TOKEN
+  MIRA_MODE
+  MIRA_DISCOVERY_LABEL
+  MIRA_DISCOVERY_HOSTNAME
+  MIRA_ENGINE_API_PORT_LABEL
+  MIRA_ENGINE_METRICS_PORT_LABEL
+  MIRA_ENGINE_DISCOVERY_INTERVAL
+  MIRA_ENGINE_UPDATE_INTERVAL
+  MIRA_KUBERNETES_PROXY_PORT
+  MIRA_LOG_LEVEL
+  MIRA_ALLOWED_RESPONSE_TIME
+  MIRA_SWARM_ENGINES_NETWORKS
+  MIRA_ROLLBAR_ACCESS_TOKEN
+  MIRA_KUBERNETES_TARGET_NAMESPACE
 )
 
 for e in "${envs[@]}"; do
-		file_env "$e"
+  file_env "$e"
 done
 
 exec "$@"

--- a/examples/kubernetes/plain.namespaced/engine-deployment.yml
+++ b/examples/kubernetes/plain.namespaced/engine-deployment.yml
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: engine
+  labels:
+    app: engine
+  annotations:
+    prometheus.io/scrape: "true"
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: engine
+        service: engine
+        qix-engine: ""
+    spec:
+      containers:
+      - name: engine
+        image: "qlikcore/engine:12.311.0"
+        imagePullPolicy: IfNotPresent
+        args: ["-S", "AcceptEULA=no"]
+        ports:
+        - containerPort: 9076
+        - containerPort: 9090

--- a/examples/kubernetes/plain.namespaced/engine-deployment.yml
+++ b/examples/kubernetes/plain.namespaced/engine-deployment.yml
@@ -15,7 +15,6 @@ spec:
         service: engine
         qix-engine: ""
     spec:
-      serviceAccount: mira
       containers:
       - name: engine
         image: "qlikcore/engine:12.311.0"

--- a/examples/kubernetes/plain.namespaced/engine-deployment.yml
+++ b/examples/kubernetes/plain.namespaced/engine-deployment.yml
@@ -15,6 +15,7 @@ spec:
         service: engine
         qix-engine: ""
     spec:
+      serviceAccount: mira
       containers:
       - name: engine
         image: "qlikcore/engine:12.311.0"

--- a/examples/kubernetes/plain.namespaced/engine-service.yml
+++ b/examples/kubernetes/plain.namespaced/engine-service.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: engine
+  labels:
+    app: engine
+spec:
+  type: NodePort
+  ports:
+    - port: 9076
+      targetPort: 9076
+      protocol: TCP
+      name: qix
+  selector:
+    app: engine

--- a/examples/kubernetes/plain.namespaced/mira-deployment.yml
+++ b/examples/kubernetes/plain.namespaced/mira-deployment.yml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: mira
+  labels:
+    app: mira
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mira
+    spec:
+      containers:
+      - name: mira
+        image: "qlikcore/mira:1.0.0"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 9100
+        env:
+        - name: MIRA_MODE
+          value: kubernetes
+        - name: MIRA_KUBERNETES_TARGET_NAMESPACE
+          value: default

--- a/examples/kubernetes/plain.namespaced/mira-deployment.yml
+++ b/examples/kubernetes/plain.namespaced/mira-deployment.yml
@@ -11,6 +11,7 @@ spec:
       labels:
         app: mira
     spec:
+      serviceAccount: mira
       containers:
       - name: mira
         image: "qlikcore/mira:1.0.0"

--- a/examples/kubernetes/plain.namespaced/mira-deployment.yml
+++ b/examples/kubernetes/plain.namespaced/mira-deployment.yml
@@ -11,7 +11,6 @@ spec:
       labels:
         app: mira
     spec:
-      serviceAccount: mira
       containers:
       - name: mira
         image: "qlikcore/mira:1.0.0"

--- a/examples/kubernetes/plain.namespaced/mira-service.yml
+++ b/examples/kubernetes/plain.namespaced/mira-service.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mira
+  labels:
+    app: mira
+spec:
+  type: NodePort
+  ports:
+    - port: 9100
+      targetPort: 9100
+      protocol: TCP
+      name: http
+  selector:
+    app: mira

--- a/examples/kubernetes/plain.namespaced/rbac/rbac-config.yaml
+++ b/examples/kubernetes/plain.namespaced/rbac/rbac-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: serviceaccounts-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:serviceaccounts

--- a/examples/kubernetes/plain.namespaced/rbac/rbac-config.yaml
+++ b/examples/kubernetes/plain.namespaced/rbac/rbac-config.yaml
@@ -1,12 +1,34 @@
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mira
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: mira
+rules:
+  - apiGroups:
+      - ""
+      - extensions
+      - apps
+    resources:
+      - pods
+      - replicasets
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: serviceaccounts-view
+  name: mira
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: view
+  name: mira
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: Group
-  name: system:serviceaccounts
+  - kind: ServiceAccount
+    name: mira

--- a/examples/kubernetes/plain.namespaced/rbac/rbac-config.yaml
+++ b/examples/kubernetes/plain.namespaced/rbac/rbac-config.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: serviceaccounts-view
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: view
 subjects:
 - apiGroup: rbac.authorization.k8s.io

--- a/src/Config.js
+++ b/src/Config.js
@@ -109,7 +109,8 @@ class Config {
      * @prop {string} kubernetesTargetNamespace - The namespace to target when looking for engines
      * @static
      */
-    Config.kubernetesTargetNamespace = process.env.MIRA_KUBERNETES_TARGET_NAMESPACE.trim() || null;
+    Config.kubernetesTargetNamespace = process.env.MIRA_KUBERNETES_TARGET_NAMESPACE
+      ? process.env.MIRA_KUBERNETES_TARGET_NAMESPACE.trim() : null;
 
     /**
      * @prop {boolean} containerized - If mira is running inside a docker container or not.

--- a/src/Config.js
+++ b/src/Config.js
@@ -106,6 +106,12 @@ class Config {
     }
 
     /**
+     * @prop {string} kubernetesTargetNamespace - The namespace to target when looking for engines
+     * @static
+     */
+    Config.kubernetesTargetNamespace = process.env.MIRA_KUBERNETES_TARGET_NAMESPACE.trim() || null;
+
+    /**
      * @prop {boolean} containerized - If mira is running inside a docker container or not.
      * @static
      */

--- a/src/orchestration/KubernetesClient.js
+++ b/src/orchestration/KubernetesClient.js
@@ -18,9 +18,19 @@ class KubernetesClient {
    * @returns {Promise<EngineContainerSpec[]>} A promise to a list of engine container specs.
    */
   async listEngines() {
-    const replicaPromise = this.k8sAppsApi.listReplicaSetForAllNamespaces();
-    const deploymentPromise = this.k8sAppsApi.listDeploymentForAllNamespaces();
-    const podPromise = this.k8sCoreApi.listPodForAllNamespaces(undefined, undefined, undefined, Config.discoveryLabel);
+    let replicaPromise;
+    let deploymentPromise;
+    let podPromise;
+    if (Config.kubernetesTargetNamespace === null) {
+      replicaPromise = this.k8sAppsApi.listReplicaSetForAllNamespaces();
+      deploymentPromise = this.k8sAppsApi.listDeploymentForAllNamespaces();
+      podPromise = this.k8sCoreApi.listPodForAllNamespaces(undefined, undefined, undefined, Config.discoveryLabel);
+    } else {
+      replicaPromise = this.k8sAppsApi.listNamespacedReplicaSet(Config.kubernetesTargetNamespace);
+      deploymentPromise = this.k8sAppsApi.listNamespacedDeployment(Config.kubernetesTargetNamespace);
+      podPromise = this.k8sCoreApi.listNamespacedPod(Config.kubernetesTargetNamespace, false, undefined, undefined, undefined, Config.discoveryLabel);
+    }
+
     const replicaMap = new Map();
     try {
       const replicaResponse = await replicaPromise;

--- a/test/test-utils/kubeMock.js
+++ b/test/test-utils/kubeMock.js
@@ -18,11 +18,23 @@ module.exports = {
             const res = await request('http://localhost:8001').get('/apis/apps/v1/deployments');
             return { body: res.body };
           },
+          listNamespacedReplicaSet: async () => {
+            const res = await request('http://localhost:8001').get('/apis/apps/v1/namespaces/my-namespace/replicasets');
+            return { body: res.body };
+          },
+          listNamespacedDeployment: async () => {
+            const res = await request('http://localhost:8001').get('/apis/apps/v1/deployments');
+            return { body: res.body };
+          },
         };
       }
       return {
         listPodForAllNamespaces: async () => {
           const res = await request('http://localhost:8001').get('/api/v1/pods?labelSelector=qix-engine');
+          return { body: res.body };
+        },
+        listNamespacedPod: async () => {
+          const res = await request('http://localhost:8001').get('/api/v1/namespaces/my-namespace/pods?labelSelector=qix-engine');
           return { body: res.body };
         },
       };

--- a/test/test-utils/kubeMock.js
+++ b/test/test-utils/kubeMock.js
@@ -23,7 +23,7 @@ module.exports = {
             return { body: res.body };
           },
           listNamespacedDeployment: async () => {
-            const res = await request('http://localhost:8001').get('/apis/apps/v1/deployments');
+            const res = await request('http://localhost:8001').get('/apis/apps/v1/namespaces/my-namespace/deployments');
             return { body: res.body };
           },
         };

--- a/test/unit/Config.spec.js
+++ b/test/unit/Config.spec.js
@@ -155,4 +155,20 @@ describe('Config', () => {
       expect(Config.engineNetworks).to.equal(undefined);
     });
   });
+
+  describe('#KUBERNETES_TARGET_NAMESPACE', () => {
+    afterEach(() => {
+      delete process.env.MIRA_KUBERNETES_TARGET_NAMESPACE;
+    });
+
+    it('should have correct default value', () => {
+      expect(Config.kubernetesTargetNamespace).to.equal(null);
+    });
+
+    it('should have value as set by MIRA_KUBERNETES_TARGET_NAMESPACE env var', () => {
+      process.env.MIRA_KUBERNETES_TARGET_NAMESPACE = '  my-namespace     ';
+      Config.init();
+      expect(Config.kubernetesTargetNamespace).to.equal('my-namespace');
+    });
+  });
 });

--- a/test/unit/orchestration/KubernetesClient.spec.js
+++ b/test/unit/orchestration/KubernetesClient.spec.js
@@ -93,7 +93,7 @@ describe('KubernetesClient', () => {
       it('should set the kubernetes property to hold the container info', async () => {
         nock('http://localhost:8001').get('/apis/apps/v1/namespaces/my-namespace/replicasets').reply(200, replicaSetSpecData.endpointsResponse);
         nock('http://localhost:8001').get('/apis/apps/v1/namespaces/my-namespace/deployments').reply(200, deploymentSpecData.endpointsResponse);
-        nock('http://localhost:8001').get('/api/v1/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
+        nock('http://localhost:8001').get('/api/v1/namespaces/my-namespace/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
         const engines = await KubernetesClient.listEngines();
         expect(engines[0].kubernetes.pod).to.deep.equal(podSpecData.endpointsResponse.items[0]);
         expect(engines[0].kubernetes.replicaSet).to.deep.equal(replicaSetSpecData.endpointsResponse.items[0]);

--- a/test/unit/orchestration/KubernetesClient.spec.js
+++ b/test/unit/orchestration/KubernetesClient.spec.js
@@ -15,6 +15,9 @@ before(() => {
 describe('KubernetesClient', () => {
   describe('#listEngines', async () => {
     describe('#allNamespaces', async () => {
+      beforeEach(() => {
+        Config.kubernetesTargetNamespace = null;
+      });
       it('should translate the kubernetes endpoints list to a mira engine list', async () => {
         nock('http://localhost:8001').get('/api/v1/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
         const engines = await KubernetesClient.listEngines();
@@ -67,7 +70,7 @@ describe('KubernetesClient', () => {
     });
 
     describe('#namespaced', async () => {
-      before(() => {
+      beforeEach(() => {
         Config.kubernetesTargetNamespace = 'my-namespace';
       });
 

--- a/test/unit/orchestration/KubernetesClient.spec.js
+++ b/test/unit/orchestration/KubernetesClient.spec.js
@@ -14,54 +14,113 @@ before(() => {
 
 describe('KubernetesClient', () => {
   describe('#listEngines', async () => {
-    it('should translate the kubernetes endpoints list to a mira engine list', async () => {
-      nock('http://localhost:8001').get('/api/v1/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
-      const engines = await KubernetesClient.listEngines();
-      const rawEngines = engines.map(pod => ({
-        engine: pod.engine,
-      }));
-      expect(rawEngines.length).to.deep.equal(2);
+    describe('#allNamespaces', async () => {
+      it('should translate the kubernetes endpoints list to a mira engine list', async () => {
+        nock('http://localhost:8001').get('/api/v1/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
+        const engines = await KubernetesClient.listEngines();
+        const rawEngines = engines.map(pod => ({
+          engine: pod.engine,
+        }));
+        expect(rawEngines.length).to.deep.equal(2);
+      });
+
+      it('should not list any engines if discovery label does not match', async () => {
+        nock('http://localhost:8001').get('/api/v1/pods?labelSelector=qix-engine').reply(200, { items: [] });
+        const engines = await KubernetesClient.listEngines();
+        expect(engines.length === 0).to.be.true;
+      });
+
+      it('should set the kubernetes property to hold the container info', async () => {
+        nock('http://localhost:8001').get('/apis/apps/v1/replicasets').reply(200, replicaSetSpecData.endpointsResponse);
+        nock('http://localhost:8001').get('/apis/apps/v1/deployments').reply(200, deploymentSpecData.endpointsResponse);
+        nock('http://localhost:8001').get('/api/v1/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
+        const engines = await KubernetesClient.listEngines();
+        expect(engines[0].kubernetes.pod).to.deep.equal(podSpecData.endpointsResponse.items[0]);
+        expect(engines[0].kubernetes.replicaSet).to.deep.equal(replicaSetSpecData.endpointsResponse.items[0]);
+        expect(engines[0].kubernetes.deployment).to.deep.equal(deploymentSpecData.endpointsResponse.items[0]);
+        expect(engines[1].kubernetes.pod).to.deep.equal(podSpecData.endpointsResponse.items[1]);
+        expect(engines[1].kubernetes.replicaSet).to.deep.equal(replicaSetSpecData.endpointsResponse.items[0]);
+        expect(engines[1].kubernetes.deployment).to.deep.equal(deploymentSpecData.endpointsResponse.items[0]);
+      });
+
+      it('should not set the replicaset or deployment kubernetes subproperty if the kubernetes API does not return any data on those endpoints', async () => {
+        nock('http://localhost:8001').get('/apis/apps/v1/replicasets').reply(401);
+        nock('http://localhost:8001').get('/apis/apps/v1/deployments').reply(401);
+        nock('http://localhost:8001').get('/api/v1/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
+        const engines = await KubernetesClient.listEngines();
+        expect(engines[0].kubernetes.pod).to.deep.equal(podSpecData.endpointsResponse.items[0]);
+        expect(engines[0].kubernetes.replicaSet).to.be.undefined;
+        expect(engines[0].kubernetes.deployment).to.be.undefined;
+        expect(engines[1].kubernetes.pod).to.deep.equal(podSpecData.endpointsResponse.items[1]);
+        expect(engines[1].kubernetes.replicaSet).to.be.undefined;
+        expect(engines[1].kubernetes.deployment).to.be.undefined;
+      });
+
+      it('should not set the local and swarm properties', async () => {
+        nock('http://localhost:8001').get('/api/v1/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
+        const engines = await KubernetesClient.listEngines();
+        expect(engines[0].local).to.be.undefined;
+        expect(engines[0].swarm).to.be.undefined;
+        expect(engines[1].local).to.be.undefined;
+        expect(engines[1].swarm).to.be.undefined;
+      });
     });
 
-    it('should not list any engines if discovery label does not match', async () => {
-      nock('http://localhost:8001').get('/api/v1/pods?labelSelector=qix-engine').reply(200, { items: [] });
-      const engines = await KubernetesClient.listEngines();
-      expect(engines.length === 0).to.be.true;
-    });
+    describe('#namespaced', async () => {
+      before(() => {
+        Config.kubernetesTargetNamespace = 'my-namespace';
+      });
 
-    it('should set the kubernetes property to hold the container info', async () => {
-      nock('http://localhost:8001').get('/apis/apps/v1/replicasets').reply(200, replicaSetSpecData.endpointsResponse);
-      nock('http://localhost:8001').get('/apis/apps/v1/deployments').reply(200, deploymentSpecData.endpointsResponse);
-      nock('http://localhost:8001').get('/api/v1/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
-      const engines = await KubernetesClient.listEngines();
-      expect(engines[0].kubernetes.pod).to.deep.equal(podSpecData.endpointsResponse.items[0]);
-      expect(engines[0].kubernetes.replicaSet).to.deep.equal(replicaSetSpecData.endpointsResponse.items[0]);
-      expect(engines[0].kubernetes.deployment).to.deep.equal(deploymentSpecData.endpointsResponse.items[0]);
-      expect(engines[1].kubernetes.pod).to.deep.equal(podSpecData.endpointsResponse.items[1]);
-      expect(engines[1].kubernetes.replicaSet).to.deep.equal(replicaSetSpecData.endpointsResponse.items[0]);
-      expect(engines[1].kubernetes.deployment).to.deep.equal(deploymentSpecData.endpointsResponse.items[0]);
-    });
 
-    it('should not set the replicaset or deployment kubernetes subproperty if the kubernetes API does not return any data on those endpoints', async () => {
-      nock('http://localhost:8001').get('/apis/apps/v1/replicasets').reply(401);
-      nock('http://localhost:8001').get('/apis/apps/v1/deployments').reply(401);
-      nock('http://localhost:8001').get('/api/v1/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
-      const engines = await KubernetesClient.listEngines();
-      expect(engines[0].kubernetes.pod).to.deep.equal(podSpecData.endpointsResponse.items[0]);
-      expect(engines[0].kubernetes.replicaSet).to.be.undefined;
-      expect(engines[0].kubernetes.deployment).to.be.undefined;
-      expect(engines[1].kubernetes.pod).to.deep.equal(podSpecData.endpointsResponse.items[1]);
-      expect(engines[1].kubernetes.replicaSet).to.be.undefined;
-      expect(engines[1].kubernetes.deployment).to.be.undefined;
-    });
+      it('should translate the kubernetes endpoints list to a mira engine list', async () => {
+        nock('http://localhost:8001').get('/api/v1/namespaces/my-namespace/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
+        const engines = await KubernetesClient.listEngines();
+        const rawEngines = engines.map(pod => ({
+          engine: pod.engine,
+        }));
+        expect(rawEngines.length).to.deep.equal(2);
+      });
 
-    it('should not set the local and swarm properties', async () => {
-      nock('http://localhost:8001').get('/api/v1/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
-      const engines = await KubernetesClient.listEngines();
-      expect(engines[0].local).to.be.undefined;
-      expect(engines[0].swarm).to.be.undefined;
-      expect(engines[1].local).to.be.undefined;
-      expect(engines[1].swarm).to.be.undefined;
+      it('should not list any engines if discovery label does not match', async () => {
+        nock('http://localhost:8001').get('/api/v1/namespaces/my-namespace/pods?labelSelector=qix-engine').reply(200, { items: [] });
+        const engines = await KubernetesClient.listEngines();
+        expect(engines.length === 0).to.be.true;
+      });
+
+      it('should set the kubernetes property to hold the container info', async () => {
+        nock('http://localhost:8001').get('/apis/apps/v1/namespaces/my-namespace/replicasets').reply(200, replicaSetSpecData.endpointsResponse);
+        nock('http://localhost:8001').get('/apis/apps/v1/namespaces/my-namespace/deployments').reply(200, deploymentSpecData.endpointsResponse);
+        nock('http://localhost:8001').get('/api/v1/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
+        const engines = await KubernetesClient.listEngines();
+        expect(engines[0].kubernetes.pod).to.deep.equal(podSpecData.endpointsResponse.items[0]);
+        expect(engines[0].kubernetes.replicaSet).to.deep.equal(replicaSetSpecData.endpointsResponse.items[0]);
+        expect(engines[0].kubernetes.deployment).to.deep.equal(deploymentSpecData.endpointsResponse.items[0]);
+        expect(engines[1].kubernetes.pod).to.deep.equal(podSpecData.endpointsResponse.items[1]);
+        expect(engines[1].kubernetes.replicaSet).to.deep.equal(replicaSetSpecData.endpointsResponse.items[0]);
+        expect(engines[1].kubernetes.deployment).to.deep.equal(deploymentSpecData.endpointsResponse.items[0]);
+      });
+
+      it('should not set the replicaset or deployment kubernetes subproperty if the kubernetes API does not return any data on those endpoints', async () => {
+        nock('http://localhost:8001').get('/apis/apps/v1/namespaces/my-namespace/replicasets').reply(401);
+        nock('http://localhost:8001').get('/apis/apps/v1/namespaces/my-namespace/deployments').reply(401);
+        nock('http://localhost:8001').get('/api/v1/namespaces/my-namespace/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
+        const engines = await KubernetesClient.listEngines();
+        expect(engines[0].kubernetes.pod).to.deep.equal(podSpecData.endpointsResponse.items[0]);
+        expect(engines[0].kubernetes.replicaSet).to.be.undefined;
+        expect(engines[0].kubernetes.deployment).to.be.undefined;
+        expect(engines[1].kubernetes.pod).to.deep.equal(podSpecData.endpointsResponse.items[1]);
+        expect(engines[1].kubernetes.replicaSet).to.be.undefined;
+        expect(engines[1].kubernetes.deployment).to.be.undefined;
+      });
+
+      it('should not set the local and swarm properties', async () => {
+        nock('http://localhost:8001').get('/api/v1/namespaces/my-namespace/pods?labelSelector=qix-engine').reply(200, podSpecData.endpointsResponse);
+        const engines = await KubernetesClient.listEngines();
+        expect(engines[0].local).to.be.undefined;
+        expect(engines[0].swarm).to.be.undefined;
+        expect(engines[1].local).to.be.undefined;
+        expect(engines[1].swarm).to.be.undefined;
+      });
     });
   });
 });


### PR DESCRIPTION
Signed-off-by: Louis Cloutier <louis.cloutier@qlik.com>

This allows:

1. Multiple miras in multiple namespaces not stepping over each other
2. Ability to run in an RBAC cluster without requiring cluster-level permissions by scoping the roles to within a single namespace.