### PR TITLE
Set specific helm version in CCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,7 @@ jobs:
     environment:
       CHANGE_MINIKUBE_NONE_USER: true
       DOCKER_REPO: qlikcore/mira
+      DESIRED_VERSION: v2.16.3 # Specify helm version
     working_directory: ~/mira
     steps:
       - attach_workspace:


### PR DESCRIPTION
Pin version `v2.16.3` of helm in Circle CI. Latest version is failing on `master` branch.